### PR TITLE
Guard Plugins collect directory creation

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
@@ -82,6 +82,11 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
             ${applyPlugin(WdkUnityPlugin)}
         """.stripIndent()
 
+        and: "the plugins directories don't exist yet"
+        assert !androidPlugins.exists()
+        assert !iOSPlugins.exists()
+        assert !webGlPlugins.exists()
+
         when: "running the setup task"
         def result = runTasksSuccessfully(WdkUnityPlugin.SETUP_TASK_NAME)
 
@@ -89,8 +94,9 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(WdkUnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME)
         result.wasExecuted("assembleIOSResources")
         result.wasExecuted("assembleAndroidResources")
-        !androidPlugins.list()
-        !iOSPlugins.list()
+        !androidPlugins.exists()
+        !iOSPlugins.exists()
+        !webGlPlugins.exists()
     }
 
     def "syncs iOS resources when configured"() {

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
@@ -94,6 +94,7 @@ class AssembleResourcesIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(WdkUnityPlugin.ASSEMBLE_RESOURCES_TASK_NAME)
         result.wasExecuted("assembleIOSResources")
         result.wasExecuted("assembleAndroidResources")
+        result.wasExecuted("assembleWebGLResources")
         !androidPlugins.exists()
         !iOSPlugins.exists()
         !webGlPlugins.exists()

--- a/src/main/groovy/wooga/gradle/wdk/unity/tasks/AndroidResourceCopyAction.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/tasks/AndroidResourceCopyAction.groovy
@@ -28,7 +28,9 @@ class AndroidResourceCopyAction extends ResourceCopyAction {
     @Override
     void copyResources(Project project, WdkPluginExtension extension, Configuration resources) {
         File collectDir = extension.getAndroidResourcePluginDir()
-        collectDir.mkdirs()
+        if(resources.size() > 0) {
+            collectDir.mkdirs()
+        }
 
         project.sync(new Action<CopySpec>() {
             @Override

--- a/src/main/groovy/wooga/gradle/wdk/unity/tasks/IOSResourceCopyAction.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/tasks/IOSResourceCopyAction.groovy
@@ -28,7 +28,9 @@ class IOSResourceCopyAction extends ResourceCopyAction {
     @Override
     void copyResources(Project project, WdkPluginExtension extension, Configuration resources) {
         File collectDir = extension.getIOSResourcePluginDir()
-        collectDir.mkdirs()
+        if(resources.size() > 0) {
+            collectDir.mkdirs()
+        }
         def artifacts = resources.resolve()
         def zipFrameworkArtifacts = artifacts.findAll { it.path =~ /\.framework.zip$/ }
 

--- a/src/main/groovy/wooga/gradle/wdk/unity/tasks/WebGLResourceCopyAction.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/tasks/WebGLResourceCopyAction.groovy
@@ -28,7 +28,9 @@ class WebGLResourceCopyAction extends ResourceCopyAction {
     @Override
     void copyResources(Project project, WdkPluginExtension extension, Configuration resources) {
         File collectDir = extension.getWebGLResourcePluginDir()
-        collectDir.mkdirs()
+        if(resources.size() > 0) {
+            collectDir.mkdirs()
+        }
         project.sync(new Action<CopySpec>() {
             @Override
             void execute(CopySpec copySpec) {


### PR DESCRIPTION
## Description

To keep a cleaner `Assets` directory we should not create the `$Plugins/$Platform` directory without having actual resources to copy.

Will patch fix testing issues here: https://github.com/wooga/wdk-unity-XCodeEditor/pull/19
resolves #6

## Changes

![IMPROVE] resource copy action by guarding collect directory creation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
