### PR TITLE
Fix compatibility for gradle > 4.4

### DIFF
--- a/src/main/groovy/wooga/gradle/wdk/unity/DefaultWdkPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/DefaultWdkPluginExtension.groovy
@@ -25,7 +25,7 @@ import wooga.gradle.unity.UnityPluginExtension
 
 class DefaultWdkPluginExtension implements WdkPluginExtension {
 
-    private final FileResolver fileResolver
+    protected final FileResolver fileResolver
     private final Project project
 
     private Factory<File> pluginsDir
@@ -54,12 +54,17 @@ class DefaultWdkPluginExtension implements WdkPluginExtension {
 
     @Override
     void setAssetsDir(File path) {
-        assetsDir = fileResolver.resolveLater(path)
+        setAssetsDir(path as Object)
     }
 
     @Override
     void setAssetsDir(Object path) {
-        assetsDir = fileResolver.resolveLater(path)
+        assetsDir = new Factory<File>() {
+            @Override
+            File create() {
+                fileResolver.resolve(path)
+            }
+        }
     }
 
     @Override
@@ -72,13 +77,18 @@ class DefaultWdkPluginExtension implements WdkPluginExtension {
     }
 
     @Override
-    void setPluginsDir(File reportsDir) {
-        pluginsDir = fileResolver.resolveLater(reportsDir)
+    void setPluginsDir(File path) {
+        setPluginsDir(path as Object)
     }
 
     @Override
-    void setPluginsDir(Object reportsDir) {
-        pluginsDir = fileResolver.resolveLater(reportsDir)
+    void setPluginsDir(Object path) {
+        pluginsDir = new Factory<File>() {
+            @Override
+            File create() {
+                fileResolver.resolve(path)
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

We used some internal API's that changed in gradle 4.4. The API `resolveLater` in `PathToFileResolver` is gone so we replicate this API with `new Factory<File>` invocations instead for now.

## Changes

![FIX] usage of removed API `resolveLater`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
