### PR TITLE
Fix missing buildTarget for perform test build tasks

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/WdkUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/WdkUnityIntegrationSpec.groovy
@@ -79,6 +79,27 @@ class WdkUnityIntegrationSpec extends UnityIntegrationSpec {
     }
 
     @Unroll
+    def "task :#taskName calls unity with correct build target"() {
+        given: "a paket.unity3d.references file with 'Wooga.AtlasBuildTools'"
+        def reference = createFile("paket.unity3d.references")
+        reference << """
+        Wooga.AtlasBuildTools
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        result.standardOutput.contains(args)
+
+        where:
+        taskName                                                | args
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "Android" | "-buildTarget android"
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "IOS"     | "-buildTarget ios"
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "WebGL"   | "-buildTarget webgl"
+    }
+
+    @Unroll
     def "verify :#taskA runs after :#taskB when execute '#execute'"() {
         given: "a paket.unity3d.references file with 'Wooga.AtlasBuildTools'"
         def reference = createFile("paket.unity3d.references")

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.tasks.internal.AbstractUnityTask
 import wooga.gradle.unity.tasks.Unity
 import wooga.gradle.unity.tasks.UnityPackage
@@ -276,11 +277,14 @@ class WdkUnityPlugin implements Plugin<Project> {
             performTestBuildTask.dependsOn cleanTestBuildTask
 
             ["Android", "IOS", "WebGL"].each { platform ->
+                BuildTarget target = BuildTarget.valueOf(platform.toLowerCase())
                 String taskName = "performTestBuild${platform}"
                 def performTestBuildPlatform = tasks.create(name: taskName, type: Unity) as Unity
                 performTestBuildPlatform.with {
                     args "-executeMethod", "Wooga.Atlas.BuildTools.BuildFromEditor.BuildTest${platform}"
-                    description = "Build test project for ${platform}"
+                    group = GROUP
+                    description = "Build test project for ${target}"
+                    buildTarget = target
                 }
 
                 performTestBuildTask.dependsOn performTestBuildPlatform


### PR DESCRIPTION
## Description

All perform test build tasks were missing the build target parameter to start Unity with the correct platform.

resolves #12 

## Changes

* ![FIX] add build target parameter to all perform test build tests

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
