### PR TITLE
Added sonarqube and sonarBuildWDK tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ github {
 }
 
 dependencies {
+    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:0.1.0"
     implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2,3]"
     implementation "commons-io:commons-io:2.8.0"
 }

--- a/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
@@ -1,0 +1,78 @@
+package wooga.gradle.wdk.unity.config
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.sonarqube.gradle.SonarQubeExtension
+import org.sonarqube.gradle.SonarQubeProperties
+import wooga.gradle.dotnetsonar.tasks.BuildSolution
+import wooga.gradle.unity.UnityPlugin
+import wooga.gradle.unity.UnityPluginExtension
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+class SonarQubeConfiguration {
+
+    private Project project
+    public String sonarTaskName
+    public String buildTaskName
+
+
+    SonarQubeConfiguration(Project project) {
+        this.project = project
+        this.sonarTaskName = "sonarqube"
+        this.buildTaskName = "sonarBuildUnity"
+    }
+
+    void configure(UnityPluginExtension unityExt,
+                   SonarQubeExtension sonarExt) {
+        def unityTestTask = project.tasks.named(UnityPlugin.Tasks.test.toString())
+        def createSolutionTask = project.tasks.named(UnityPlugin.Tasks.generateSolution.toString())
+
+        unityExt.enableTestCodeCoverage = true
+        def sonarBuild = project.tasks.register(buildTaskName, BuildSolution) { task ->
+            task.dependsOn(createSolutionTask)
+            task.mustRunAfter(unityTestTask)
+            setupSonarBuildUnityDefaults(task, unityExt)
+        }
+        project.tasks.register(sonarTaskName) {task ->
+            task.dependsOn(unityTestTask, sonarBuild)
+            task.mustRunAfter(unityTestTask)
+        }
+        project.afterEvaluate { //needs to be done after evaluate to be able to fill reportsDir property
+            def assetsDir = unityExt.assetsDir.get().asFile.path
+            def reportsDir = unityExt.reportsDir.get().asFile.path
+            sonarExt.properties(sonarqubeUnityDefaults(assetsDir, reportsDir))
+        }
+    }
+    private void setupSonarBuildUnityDefaults(BuildSolution task, UnityPluginExtension unityExt) {
+        def propsFixResource = SonarQubeConfiguration.class.getResourceAsStream("/atlas-build-unity.project-fixes.props")
+        def propsFixTmpFile = File.createTempFile("atlas-build-unity", ".project-fixes.props")
+        propsFixResource.withStream {inputStream ->
+            Files.copy(inputStream, Paths.get(propsFixTmpFile.absolutePath), StandardCopyOption.REPLACE_EXISTING)
+        }
+
+        task.solution.convention(project.layout.projectDirectory.file("${project.name}.sln"))
+        task.dotnetExecutable.convention(unityExt.dotnetExecutable)
+        task.addEnvironment("FrameworkPathOverride",
+                unityExt.monoFrameworkDir.map{it.asFile.absolutePath} )
+        task.extraArgs.add("/p:CustomBeforeMicrosoftCommonProps=${propsFixTmpFile.absolutePath}")
+
+    }
+
+    private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
+        return {
+
+            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D/**")
+            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")
+        }
+    }
+
+    private static void addPropertyIfNotExists(SonarQubeProperties properties, String key, Object value) {
+        if(!properties.properties.containsKey(key)) {
+            properties.property(key, value)
+        }
+    }
+}

--- a/src/main/resources/atlas-build-unity.project-fixes.props
+++ b/src/main/resources/atlas-build-unity.project-fixes.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Our wooga projects get falsely flagged as test projects due to `nunit` reference. -->
+    <SonarQubeTestProject>false</SonarQubeTestProject>
+    <!-- Unity default .sln export adds the Unity installed CSC tools which have issues to work with `.editoconfig` -->
+    <CscToolPath></CscToolPath>
+    <CscToolExe></CscToolExe>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Unity 2020 default export disables all it's references. (known bug: https://issuetracker.unity3d.com/issues/referenceoutputassembly-key-is-set-to-false-in-project-references)  -->
+    <ProjectReference Update="*.csproj">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Description
Added WDK-opinionated sonarqube support by configuring `atlas-dotnet-sonarqube` tasks for a WDK environment, in a similar fashion of what was done in `atlas-build-unity`, see https://github.com/wooga/atlas-build-unity/pull/122.


## Changes
* ![ADD] This plugin now applies the `atlas-dotnet-sonarqube` plugin.
* ![ADD] sonarqube integration using the `atlas-dotnet-sonarqube` plugin.
* ![CHANGE] unity test code coverage enabled by default




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
