### PR TITLE
Added unity tests folder to default sonarqube exclusions

### DIFF
--- a/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
@@ -63,7 +63,8 @@ class SonarQubeConfiguration {
 
     private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
         return {
-
+            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${assetsDir}/**/Tests/**")
+            addPropertyIfNotExists(it, "sonar.coverage.exclusions", "${assetsDir}/**/Tests/**")
             addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D/**")
             addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
             addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")

--- a/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
@@ -118,6 +118,8 @@ class WdkUnityPluginSpec extends ProjectSpec {
         def assetsDir = unityExt.assetsDir.get().asFile.path
         def reportsDir = unityExt.reportsDir.get().asFile.path
         properties["sonar.exclusions"] == "${assetsDir}/Paket.Unity3D/**"
+        properties["sonar.cpd.exclusions"] == "${assetsDir}/**/Tests/**"
+        properties["sonar.coverage.exclusions"] == "${assetsDir}/**/Tests/**"
         properties["sonar.cs.nunit.reportsPaths"] == "${reportsDir}/**/*.xml"
         properties["sonar.cs.opencover.reportsPaths"] == "${reportsDir}/**/*.xml"
     }


### PR DESCRIPTION
## Description
Unity project Assets/Tests folder added to default sonarqube coverage (`sonar.coverage.exclusions`) and cpd(`sonar.cpd.exclusions`) exclusions. 


## Changes
* ![ADD] Assets/Tests folder added to default sonarqube coverage and cdp exclusions. 




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
