### PR TITLE
Fixed exclusions path [ATLAS-390]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 withCredentials([string(credentialsId: 'atlas_wdk_unity_coveralls_token', variable: 'coveralls_token'),
                  string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
     buildGradlePlugin platforms: ['macos', 'windows', 'linux'],
-            coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment:[]
+            coverallsToken: coveralls_token, sonarToken: sonar_token
 }

--- a/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/config/SonarQubeConfiguration.groovy
@@ -31,7 +31,7 @@ class SonarQubeConfiguration {
         def createSolutionTask = project.tasks.named(UnityPlugin.Tasks.generateSolution.toString())
 
         unityExt.enableTestCodeCoverage = true
-        def sonarBuild = project.tasks.register(buildTaskName, BuildSolution) { task ->
+        def sonarBuild = project.tasks.register(buildTaskName, BuildSolution) {task ->
             task.dependsOn(createSolutionTask)
             task.mustRunAfter(unityTestTask)
             setupSonarBuildUnityDefaults(task, unityExt)
@@ -41,8 +41,8 @@ class SonarQubeConfiguration {
             task.mustRunAfter(unityTestTask)
         }
         project.afterEvaluate { //needs to be done after evaluate to be able to fill reportsDir property
-            def assetsDir = unityExt.assetsDir.get().asFile.path
-            def reportsDir = unityExt.reportsDir.get().asFile.path
+            def assetsDir = unityExt.assetsDir.get().asFile
+            def reportsDir = unityExt.reportsDir.get().asFile
             sonarExt.properties(sonarqubeUnityDefaults(assetsDir, reportsDir))
         }
     }
@@ -61,13 +61,14 @@ class SonarQubeConfiguration {
 
     }
 
-    private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
+    private Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(File assetsDir, File reportsDir) {
+       def relativeAssetsDir = project.projectDir.relativePath(assetsDir)
         return {
-            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${assetsDir}/**/Tests/**")
-            addPropertyIfNotExists(it, "sonar.coverage.exclusions", "${assetsDir}/**/Tests/**")
-            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D/**")
-            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
-            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${relativeAssetsDir}/**/Tests/**")
+            addPropertyIfNotExists(it, "sonar.coverage.exclusions", "${relativeAssetsDir}/**/Tests/**")
+            addPropertyIfNotExists(it, "sonar.exclusions", "${relativeAssetsDir}/Paket.Unity3D/**")
+            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir.path}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir.path}/**/*.xml")
         }
     }
 

--- a/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
@@ -115,11 +115,10 @@ class WdkUnityPluginSpec extends ProjectSpec {
         def unityExt = project.extensions.getByType(UnityPluginExtension)
         and: "sonarqube extension is configured with defaults"
         def properties = sonarExt.computeSonarProperties(project)
-        def assetsDir = unityExt.assetsDir.get().asFile.path
         def reportsDir = unityExt.reportsDir.get().asFile.path
-        properties["sonar.exclusions"] == "${assetsDir}/Paket.Unity3D/**"
-        properties["sonar.cpd.exclusions"] == "${assetsDir}/**/Tests/**"
-        properties["sonar.coverage.exclusions"] == "${assetsDir}/**/Tests/**"
+        properties["sonar.exclusions"] == "Assets/Paket.Unity3D/**"
+        properties["sonar.cpd.exclusions"] == "Assets/**/Tests/**"
+        properties["sonar.coverage.exclusions"] == "Assets/**/Tests/**"
         properties["sonar.cs.nunit.reportsPaths"] == "${reportsDir}/**/*.xml"
         properties["sonar.cs.opencover.reportsPaths"] == "${reportsDir}/**/*.xml"
     }


### PR DESCRIPTION
## Description
Path to sonarqube exclusions are now relative to `project.projectDir`. If `unity.assetsDir` is not in the project directory file tree (which shouldn't happen), the path will continue to be absolute, as there is no way to know how which directory it is relative to.

## Changes
* ![FIX] path to sonarqube exclusion properties are now relative


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
