### PR TITLE
Add snyk integration [ATLAS-713]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([string(credentialsId: 'atlas_wdk_unity_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
     buildGradlePlugin platforms: ['macos', 'windows', 'linux'],
             coverallsToken: coveralls_token, sonarToken: sonar_token
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,11 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.3'
+    id 'net.wooga.plugins' version '2.3.0'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
+    
 }
 
 group 'net.wooga.gradle'
@@ -40,8 +44,12 @@ github {
     repositoryName = "wooga/atlas-wdk-unity"
 }
 
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+
 dependencies {
-    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:(0.2,0.3]"
-    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2,3]"
-    implementation "commons-io:commons-io:2.8.0"
+    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:[0.2,0.3["
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:[2,3["
+    implementation "commons-io:commons-io:2.11.0"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,5 +14,11 @@
  * limitations under the License.
  *
  */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-wdk-unity'


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
