### PR TITLE
Add task to generate upm packages and to publish them

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,12 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([
-                string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
-                string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
-    buildGradlePlugin platforms: ['macos', 'windows', 'linux'],
-            sonarToken: sonar_token
+withCredentials([                    
+                    string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                    string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN'),
+                    usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
+                    usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy')
+                 ]) {
+    def testEnvironment = [ "artifactoryCredentials=${artifactory_publish}" ]
+    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment : testEnvironment
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,10 @@
 withCredentials([                    
                     string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
                     string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN'),
-                    usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
-                    usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy')
+                    usernameColonPassword(credentialsId: 'atlas_upm_integration_user', variable: 'atlas_upm_integration_user')
                  ]) {
-    def testEnvironment = [ "artifactoryCredentials=${artifactory_publish}" ]
-    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment : testEnvironment
+    def testEnvironment = [
+                                "repositoryCredentials=${atlas_upm_integration_user}"
+                          ]
+    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], sonarToken: sonar_token, testEnvironment : testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2018-2022 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,11 @@ plugins {
     id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
+repositories  {
+    mavenLocal()
+    mavenCentral()
+}
+
 group 'net.wooga.gradle'
 description = 'Plugin for wooga unity package development.'
 
@@ -33,7 +38,7 @@ pluginBundle {
 
 gradlePlugin {
     plugins {
-        plugins {
+        wdkUnity {
             id = 'net.wooga.wdk-unity'
             displayName = 'Wooga internal plugin to help setup depencencies for unity packages'
             description = 'This plugin provides tasks to define and copy development dependencies into the Unity3D project'
@@ -52,7 +57,15 @@ cveHandler {
 
 dependencies {
     implementation "net.wooga.gradle:dotnet-sonarqube:[0.4,0.5["
-    implementation "net.wooga.gradle:unity:[3,4["
+    implementation "net.wooga.gradle:unity:[3.1,4["
     implementation "commons-io:commons-io:2.11.0"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
+
+    implementation "org.jfrog.buildinfo:build-info-extractor-gradle:4.28.2"
+
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2)'
+    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:[2,3)') {
+        exclude module: 'logback-classic'
+    }
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
 }
 
 repositories  {
-    mavenLocal()
     mavenCentral()
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,10 +15,10 @@
  *
  */
 pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 rootProject.name = 'wdk-unity'

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
@@ -1,0 +1,168 @@
+package wooga.gradle.wdk.unity
+
+
+import org.gradle.api.file.Directory
+import org.jfrog.artifactory.client.Artifactory
+import org.jfrog.artifactory.client.ArtifactoryClientBuilder
+import org.jfrog.artifactory.client.model.RepoPath
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.unity.utils.PackageManifestBuilder
+
+class PublishWdkUnityIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
+
+    @Shared
+    def packageTitle = "UpmTestPackage"
+
+    @Shared
+    def packageVersion = "0.0.1"
+
+    @Shared
+    def packageName = "com.wooga.${packageTitle.toLowerCase()}"
+
+    @Shared
+    def packageArtifactName = "${packageName}-${packageVersion}"
+
+    @Shared
+    def packageFileName = "${packageArtifactName}.tgz"
+
+    @Shared
+    def artifactoryUrl = "https://wooga.jfrog.io/wooga"
+
+    @Shared
+    Artifactory artifactory
+
+    @Shared
+    def artifactoryRepoName = "atlas-upm-integrationTest"
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(WdkUnityPlugin)}
+        """.stripIndent()
+    }
+
+    def setupSpec() {
+        String artifactoryCredentials = System.getenv("artifactoryCredentials")
+        assert artifactoryCredentials
+        def credentials = artifactoryCredentials.split(':')
+        artifactory = ArtifactoryClientBuilder.create()
+            .setUrl(artifactoryUrl)
+            .setUsername(credentials[0])
+            .setPassword(credentials[1])
+            .build()
+    }
+
+    def cleanup() {
+        cleanupArtifactory(artifactoryRepoName, packageFileName)
+    }
+
+    def cleanupArtifactory(String repoName, String artifactName) {
+        List<RepoPath> searchItems = artifactory.searches()
+            .repositories(repoName)
+            .artifactsByName(artifactName)
+            .doSearch()
+
+        for (RepoPath searchItem : searchItems) {
+            String repoKey = searchItem.getRepoKey()
+            String itemPath = searchItem.getItemPath()
+            artifactory.repository(repoName).delete(itemPath)
+        }
+    }
+
+    def hasPackageOnArtifactory(String repoName, String artifactName) {
+        List<RepoPath> packages = artifactory.searches()
+            .repositories(repoName)
+            .artifactsByName(artifactName)
+            .doSearch()
+
+        assert packages.size() == 1 : "Could not find artifact `${artifactName}` on repository ${repoName}"
+        true
+    }
+
+    /**
+     * The main test, which publishes directly to the JFrog remote artifactory
+     */
+    def "publishes to artifactory"() {
+
+        given: "a sample project directory with a package manifest"
+        def packageDir = writeTestPackage(packageTitle, packageName)
+        assert packageDir.exists()
+
+        and: "configuration of the main plugin and the artifactory plugin"
+        String nugetKey = System.getenv("NUGET_KEY")
+        assert nugetKey
+        def userName = nugetKey.split(":").first()
+        def password = nugetKey.split(":").last()
+        buildFile << """
+wdk {
+generateMetaFiles.set(false)
+}
+
+artifactory {
+    contextUrl = "https://wooga.jfrog.io/artifactory/"
+    publish {
+        repository {
+            repoKey = ${wrapValueBasedOnType(artifactoryRepoName, String)}
+            username = ${wrapValueBasedOnType(userName, String)}
+            password = ${wrapValueBasedOnType(password, String)}
+        }
+    }
+}
+"""
+
+        and: "configuration of the task to generate the package"
+        buildFile << """
+upmPack {
+packageDirectory.set(${wrapValueBasedOnType(packageTitle, Directory)})
+packageName = ${wrapValueBasedOnType(packageName, String)}
+archiveVersion.set(${wrapValueBasedOnType(packageVersion, String)})
+}
+"""
+
+        when:
+        def result = runTasksSuccessfully(WdkUnityPlugin.GENERATE_UPM_PACKAGE_TASK_NAME, "publish")
+
+        then:
+        result.success
+
+        def buildDir = new File(projectDir, "build")
+        buildDir.exists()
+        def distDir = new File(buildDir, "distributions")
+        distDir.exists()
+        def packageFile = new File(distDir, packageFileName)
+        packageFile.exists()
+
+        hasPackageOnArtifactory(artifactoryRepoName, packageArtifactName)
+    }
+
+    @Unroll
+    def "does not add generate meta files task if not set by extension"() {
+        given: "configuration of the main plugin"
+        directory("Foobar")
+        buildFile << """
+wdk {
+packageDirectory.set(${wrapValueBasedOnType("Foobar", Directory)})
+generateMetaFiles.set(${wrapValueBasedOnType(generateMetaFiles, Boolean)})
+}
+"""
+        when:
+        def result = runTasksSuccessfully(WdkUnityPlugin.GENERATE_UPM_PACKAGE_TASK_NAME, "--dry-run")
+
+        then:
+        present == outputContains(result, WdkUnityPlugin.GENERATE_META_FILES_TASK_NAME)
+
+        where:
+        generateMetaFiles | present
+        true              | true
+        false             | false
+    }
+
+    File writeTestPackage(String packageDirectory, String packageName) {
+        def packageDir = directory(packageDirectory)
+        def packageManifestFile = file("package.json", packageDir)
+        packageManifestFile.write(new PackageManifestBuilder(packageName, packageVersion).build())
+        file("Sample.cs", packageDir).write("class Sample {}")
+        file("Sample.cs.meta", packageDir).write("META")
+        packageDir
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
@@ -41,8 +41,12 @@ class PublishWdkUnityIntegrationSpec extends com.wooga.gradle.test.IntegrationSp
         """.stripIndent()
     }
 
+    def getCredentials() {
+        System.getenv("repositoryCredentials") ?: System.getenv("atlas_upm_integration_user")
+    }
+
     def setupSpec() {
-        String artifactoryCredentials = System.getenv("artifactoryCredentials")
+        String artifactoryCredentials = getCredentials()
         assert artifactoryCredentials
         def credentials = artifactoryCredentials.split(':')
         artifactory = ArtifactoryClientBuilder.create()
@@ -89,10 +93,10 @@ class PublishWdkUnityIntegrationSpec extends com.wooga.gradle.test.IntegrationSp
         assert packageDir.exists()
 
         and: "configuration of the main plugin and the artifactory plugin"
-        String nugetKey = System.getenv("NUGET_KEY")
-        assert nugetKey
-        def userName = nugetKey.split(":").first()
-        def password = nugetKey.split(":").last()
+        String repositoryCredentials = getCredentials()
+        assert repositoryCredentials
+        def userName = repositoryCredentials.split(":").first()
+        def password = repositoryCredentials.split(":").last()
         buildFile << """
 wdk {
 generateMetaFiles.set(false)

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkPluginExtension.groovy
@@ -20,7 +20,10 @@ package wooga.gradle.wdk.unity
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
 import org.gradle.util.GUtil
 
@@ -44,7 +47,11 @@ abstract class WdkPluginExtension {
         pluginsDir.set(value)
     }
 
+    // TODO: Rename to 'woogaAssetsDir' maybe?
     private final DirectoryProperty assetsDir = objects.directoryProperty()
+    /**
+     * @return The directory within the Unity project that contains the wdk assets. By convention within 'Assets/Wooga'
+     */
     DirectoryProperty getAssetsDir() {
         assetsDir
     }
@@ -96,5 +103,23 @@ abstract class WdkPluginExtension {
     void setEditorDependenciesToMoveDuringTestBuild(Iterable<String> dependencies) {
         editorDependeciesToMoveDuringTestBuild.clear()
         editorDependeciesToMoveDuringTestBuild.addAll(dependencies)
+    }
+
+    private final DirectoryProperty packageDirectory = objects.directoryProperty()
+    /**
+     * @return The directory where the UPM package sources of the WDK are located.
+     * At its root, it must contain a package manifest file (package.json) file.
+     */
+    DirectoryProperty getPackageDirectory() {
+        packageDirectory
+    }
+
+    private final Property<Boolean> generateMetaFiles = objects.property(Boolean)
+    @Input
+    Property<Boolean> getGenerateMetaFiles() {
+        generateMetaFiles
+    }
+    void setGenerateMetaFiles(Provider<Boolean> value) {
+        generateMetaFiles.set(value)
     }
 }

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
@@ -24,6 +24,15 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.ivy.IvyPublication
+import org.gradle.api.publish.ivy.plugins.IvyPublishPlugin
+import org.gradle.api.publish.plugins.PublishingPlugin
+import org.jfrog.gradle.plugin.artifactory.ArtifactoryPlugin
+import org.jfrog.gradle.plugin.artifactory.dsl.ArtifactoryPluginConvention
+import org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig
+import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
 import org.sonarqube.gradle.SonarQubeExtension
 import wooga.gradle.dotnetsonar.DotNetSonarqubePlugin
 import org.gradle.api.internal.file.FileResolver
@@ -39,6 +48,7 @@ import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.UnityTask
 import wooga.gradle.unity.models.BuildTarget
+import wooga.gradle.unity.tasks.GenerateUpmPackage
 import wooga.gradle.unity.tasks.Unity
 import wooga.gradle.wdk.unity.actions.AndroidResourceCopyAction
 import wooga.gradle.wdk.unity.config.SonarQubeConfiguration
@@ -47,23 +57,29 @@ import wooga.gradle.wdk.unity.actions.IOSResourceCopyAction
 import wooga.gradle.wdk.unity.actions.WebGLResourceCopyAction
 
 import javax.inject.Inject
+import java.security.cert.Extension
 import java.util.concurrent.Callable
 
 class WdkUnityPlugin implements Plugin<Project> {
 
     static Logger logger = Logging.getLogger(WdkUnityPlugin)
 
+    static String GROUP = "wdk"
+    static String EXTENSION_NAME = "wdk"
+
     static String ASSEMBLE_RESOURCES_TASK_NAME = "assembleResources"
     static String ASSEMBLE_IOS_RESOURCES_TASK_NAME = "assembleIOSResources"
     static String ASSEMBLE_ANDROID_RESOURCES_TASK_NAME = "assembleAndroidResources"
     static String ASSEMBLE_WEBGL_RESOURCES_TASK_NAME = "assembleWebGLResources"
     static String SETUP_TASK_NAME = "setup"
-    static String GROUP = "wdk"
-    static String EXTENSION_NAME = "wdk"
+
     static String ANDROID_RESOURCES_CONFIGURATION_NAME = "android"
     static String IOS_RESOURCES_CONFIGURATION_NAME = "ios"
     static String WEBGL_RESOURCES_CONFIGURATION_NAME = "webgl"
     static String RUNTIME_CONFIGURATION_NAME = "runtime"
+
+    static String GENERATE_UPM_PACKAGE_TASK_NAME = "upmPack"
+    static String GENERATE_META_FILES_TASK_NAME = "generateMetaFiles"
 
     static String PERFORM_TEST_BUILD_TASK_NAME = "performTestBuild"
     static String CLEAN_TEST_BUILD_TASK_NAME = "cleanTestBuild"
@@ -87,6 +103,8 @@ class WdkUnityPlugin implements Plugin<Project> {
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(UnityPlugin.class)
         project.pluginManager.apply(DotNetSonarqubePlugin.class)
+        project.pluginManager.apply(ArtifactoryPlugin.class)
+        project.pluginManager.apply(IvyPublishPlugin.class)
 
         WdkPluginExtension extension = project.extensions.create(WdkPluginExtension, EXTENSION_NAME, DefaultWdkPluginExtension, project)
 
@@ -98,9 +116,8 @@ class WdkUnityPlugin implements Plugin<Project> {
         configureUnityTaskDependencies(project)
         createTestBuildTasks(project, extension)
         configureSonarqubeTasks(project)
+        configureUpmPublish(project, extension)
     }
-
-
 
     private static void configureExtension(Project project, WdkPluginExtension extension) {
         UnityPluginExtension unity = project.extensions.getByType(UnityPluginExtension)
@@ -114,6 +131,25 @@ class WdkUnityPlugin implements Plugin<Project> {
         extension.iosResourcePluginDir.convention(extension.pluginsDir.dir(WdkUnityPluginConventions.IOS_PLUGIN_DIRECTORY))
         extension.androidResourcePluginDir.convention(extension.pluginsDir.dir(WdkUnityPluginConventions.ANDROID_PLUGIN_DIRECTORY))
         extension.webGLResourcePluginDir.convention(extension.pluginsDir.dir(WdkUnityPluginConventions.WEBGL_PLUGIN_DIRECTORY))
+
+        extension.generateMetaFiles.convention(true)
+        // Try tp deduce the package directory within the Unity assets directories, where the root of the sources of the wdk are
+        // For example: Assets/Wooga/Foobar/*
+        extension.packageDirectory.convention(project.provider({
+            Directory result = null
+            if (extension.assetsDir.present) {
+                def woogaDir = extension.assetsDir.get()
+                def files = woogaDir.asFile.listFiles()
+                if (files != null &&  files.length == 1 && files[0].isDirectory()) {
+                    def packageDir = files[0]
+                    result = woogaDir.dir(packageDir.name)
+                }
+            }
+            if (result == null) {
+                logger.warn("Could not deduce the package directory for this wdk")
+            }
+            result
+        }))
     }
 
     private static void addLifecycleTasks(Project project) {
@@ -162,28 +198,28 @@ class WdkUnityPlugin implements Plugin<Project> {
         Configuration webglResources = project.configurations[WEBGL_RESOURCES_CONFIGURATION_NAME]
 
         def iOSResourceCopy = project.tasks.register("assembleIOSResources", DefaultResourceCopyTask,
-                { t ->
-                    t.description = "gathers all additional iOS files into the Plugins/iOS directory of the unity project"
-                    t.dependsOn(iOSResources)
-                    t.resources = iOSResources
-                    t.doLast(new IOSResourceCopyAction())
-                })
+            { t ->
+                t.description = "gathers all additional iOS files into the Plugins/iOS directory of the unity project"
+                t.dependsOn(iOSResources)
+                t.resources = iOSResources
+                t.doLast(new IOSResourceCopyAction())
+            })
 
         def androidResourceCopy = project.tasks.register("assembleAndroidResources", DefaultResourceCopyTask,
-                { t ->
-                    t.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
-                    t.dependsOn(androidResources)
-                    t.resources androidResources
-                    t.doLast(new AndroidResourceCopyAction())
-                })
+            { t ->
+                t.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
+                t.dependsOn(androidResources)
+                t.resources androidResources
+                t.doLast(new AndroidResourceCopyAction())
+            })
 
         def webglResourceCopy = project.tasks.register("assembleWebGLResources", DefaultResourceCopyTask,
-                { t ->
-                    t.description = "gathers all webgl related files into the Plugins/webGL directory of the unity project"
-                    t.dependsOn(webglResources)
-                    t.resources webglResources
-                    t.doLast(new WebGLResourceCopyAction())
-                })
+            { t ->
+                t.description = "gathers all webgl related files into the Plugins/webGL directory of the unity project"
+                t.dependsOn(webglResources)
+                t.resources webglResources
+                t.doLast(new WebGLResourceCopyAction())
+            })
 
         def assembleTask = project.tasks[ASSEMBLE_RESOURCES_TASK_NAME]
         assembleTask.dependsOn iOSResourceCopy, androidResourceCopy, webglResourceCopy
@@ -305,5 +341,68 @@ class WdkUnityPlugin implements Plugin<Project> {
             buildTaskName = SONARQUBE_BUILD_TASK_NAME
             return it
         }.configure(unityExt, sonarExt)
+    }
+
+    private static void configureUpmPublish(Project project, WdkPluginExtension extension) {
+
+        def unityExtension = project.extensions.getByType(UnityPluginExtension)
+        def group = "UPM"
+
+        // Create the tasks
+        def upmGenerateMetaFiles = project.tasks.register(GENERATE_META_FILES_TASK_NAME, Unity) {
+            it.group = group
+        }
+        def upmPack = project.tasks.register(GENERATE_UPM_PACKAGE_TASK_NAME, GenerateUpmPackage) {
+            if (extension.generateMetaFiles.present && extension.generateMetaFiles.get()){
+                it.dependsOn(upmGenerateMetaFiles)
+            }
+            it.group = group
+            it.packageDirectory.convention(extension.packageDirectory)
+        }
+
+        // Create the configuration
+        def config = project.configurations.maybeCreate(WdkUnityPluginConventions.upmConfigurationName)
+        config.transitive = false
+        def upmArtifact = project.artifacts.add(WdkUnityPluginConventions.upmConfigurationName, upmPack)
+
+        // Create the publication object
+        def publishing = project.extensions.getByType(PublishingExtension)
+        def upmPublication = publishing.publications.maybeCreate(WdkUnityPluginConventions.upmPublicationName, IvyPublication)
+        // TODO: Try to adjust? It has to be evaluated later
+        project.afterEvaluate {
+            upmPublication.setModule(upmPack.flatMap({ it.packageName }).getOrNull())
+        }
+
+        upmPublication.artifact(upmArtifact)
+
+        // Configure the artifactory plugin
+        // Some properties, such as 'contextUrl', `publish.repository.repoKey|username|password` have to be configured by the user
+        def artifactory = (ArtifactoryPluginConvention) project.convention.plugins.get("artifactory")
+        artifactory.publish { PublisherConfig publisherConfig ->
+            publisherConfig.repository { repo ->
+                repo.ivy { PublisherConfig.Repository it ->
+                    it.artifactLayout = '[module]/-/[module]-[revision].[ext]'
+                    it.mavenCompatible = false
+                }
+            }
+        }
+
+        project.tasks.withType(ArtifactoryTask).configureEach({ defaultTask ->
+            defaultTask.publications(WdkUnityPluginConventions.upmPublicationName)
+            defaultTask.publishArtifacts = false
+            defaultTask.publishIvy = false
+        })
+
+        // Configure the publishing task dependencies
+        def artifactoryPublishTask = project.tasks.getByName("artifactoryPublish")
+        def publishTask = project.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+        publishTask.dependsOn(artifactoryPublishTask)
+
+        if (project.rootProject != project) {
+            def rootPublishTask = project.rootProject.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+            rootPublishTask.dependsOn(publishTask)
+        }
+
+
     }
 }

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPluginConventions.groovy
@@ -24,4 +24,7 @@ class WdkUnityPluginConventions {
     static String WEBGL_PLUGIN_DIRECTORY = "WebGL"
     static String PAKET_UNITY_3D_INSTALL_DIRECTORY = "Paket.Unity3D"
 
+    static String upmConfigurationName = "upm"
+    static String upmPublicationName = "upm"
+
 }

--- a/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
@@ -25,6 +25,7 @@ import wooga.gradle.dotnetsonar.SonarScannerExtension
 import wooga.gradle.dotnetsonar.tasks.BuildSolution
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.tasks.GenerateUpmPackage
 import wooga.gradle.wdk.unity.tasks.ResourceCopyTask
 
 class WdkUnityPluginSpec extends ProjectSpec {
@@ -66,6 +67,7 @@ class WdkUnityPluginSpec extends ProjectSpec {
         WdkUnityPlugin.SETUP_TASK_NAME                      | DefaultTask
         WdkUnityPlugin.SONARQUBE_BUILD_TASK_NAME            | BuildSolution
         WdkUnityPlugin.SONARQUBE_TASK_NAME                  | DefaultTask
+        WdkUnityPlugin.GENERATE_UPM_PACKAGE_TASK_NAME       | GenerateUpmPackage
     }
 
     @Unroll
@@ -138,10 +140,10 @@ class WdkUnityPluginSpec extends ProjectSpec {
         buildTask.solution.get().asFile == new File(projectDir, "${project.name}.sln")
         buildTask.dotnetExecutable.getOrElse(null) == unityExt.dotnetExecutable.getOrElse(null)
         buildTask.environment.getting("FrameworkPathOverride").getOrElse(null) ==
-                unityExt.monoFrameworkDir.map { it.asFile.absolutePath }.getOrElse(null)
+            unityExt.monoFrameworkDir.map { it.asFile.absolutePath }.getOrElse(null)
         buildTask.extraArgs.get().any {
             it.startsWith("/p:CustomBeforeMicrosoftCommonProps=") &&
-                    it.endsWith(".project-fixes.props")
+                it.endsWith(".project-fixes.props")
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a conventional task to generate the UPM package for the given unity project. This involves adding the JFrog artifactory plugin, and hooking into the `publish` task.

## Changes
* ![ADD] `upmPack` plugin task
* ![ADD] `artifactory` plugin from Jfrog

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
