### PR TITLE
Add predicate for the generate meta files task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ cveHandler {
 
 dependencies {
     implementation "net.wooga.gradle:dotnet-sonarqube:[0.4,0.5["
-    implementation "net.wooga.gradle:unity:[3.1,4["
+    implementation "net.wooga.gradle:unity:[3.1.1,4["
     implementation "commons-io:commons-io:2.11.0"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
 

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/IntegrationSpec.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.wdk.unity
 
-class IntegrationSpec extends nebula.test.IntegrationSpec {
+class IntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/PublishWdkUnityIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package wooga.gradle.wdk.unity
 
-
+import org.gradle.api.DefaultTask
 import org.gradle.api.file.Directory
 import org.jfrog.artifactory.client.Artifactory
 import org.jfrog.artifactory.client.ArtifactoryClientBuilder
@@ -9,7 +9,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.unity.utils.PackageManifestBuilder
 
-class PublishWdkUnityIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec {
+class PublishWdkUnityIntegrationSpec extends IntegrationSpec {
 
     @Shared
     def packageTitle = "UpmTestPackage"

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/WdkUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/WdkUnityIntegrationSpec.groovy
@@ -273,8 +273,24 @@ class WdkUnityIntegrationSpec extends UnityIntegrationSpec {
         true  | true           | true  | "set according to convention"
         true  | false          | false | "missing manifest file"
         false | true           | false | "not set"
+    }
 
+    def "upm pack is skipped if no package json is set"() {
+        given:
+        buildFile << """ unity {
+        unityPath = file(${wrapValueBasedOnType(File.createTempFile("foo", "bar"), String)})
+        }"""
 
+        when:
+        def result = runTasks(upmTaskName)
+
+        then:
+        result.wasSkipped(upmTaskName)
+        result.wasSkipped(generateMetaFilesTaskName)
+
+        where:
+        upmTaskName = "upmPack"
+        generateMetaFilesTaskName = "generateMetaFiles"
     }
 
 

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
@@ -342,6 +342,13 @@ class WdkUnityPlugin implements Plugin<Project> {
             it.packageDirectory.convention(extension.packageDirectory)
         }
 
+        upmGenerateMetaFiles.configure({
+            it.onlyIf {
+                upmPack.get().onlyIf.isSatisfiedBy(upmPack.get())
+            }
+        })
+
+
         // Create the configuration
         def config = project.configurations.maybeCreate(WdkUnityPluginConventions.upmConfigurationName)
         config.transitive = false


### PR DESCRIPTION
## Description
Reuse the predicate from  `upmPack` into `generateMetaFiles` to ensure its not called.

## Changes
* ![ADD] Reuse the predicate from  `upmPack` into `generateMetaFiles` to ensure its not called

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
