### PR TITLE
Fix publish with non set upm package directory

### DIFF
--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
@@ -180,28 +180,28 @@ class WdkUnityPlugin implements Plugin<Project> {
         Configuration webglResources = project.configurations[WEBGL_RESOURCES_CONFIGURATION_NAME]
 
         def iOSResourceCopy = project.tasks.register("assembleIOSResources", DefaultResourceCopyTask,
-            { t ->
-                t.description = "gathers all additional iOS files into the Plugins/iOS directory of the unity project"
-                t.dependsOn(iOSResources)
-                t.resources = iOSResources
-                t.doLast(new IOSResourceCopyAction())
-            })
+                { t ->
+                    t.description = "gathers all additional iOS files into the Plugins/iOS directory of the unity project"
+                    t.dependsOn(iOSResources)
+                    t.resources = iOSResources
+                    t.doLast(new IOSResourceCopyAction())
+                })
 
         def androidResourceCopy = project.tasks.register("assembleAndroidResources", DefaultResourceCopyTask,
-            { t ->
-                t.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
-                t.dependsOn(androidResources)
-                t.resources androidResources
-                t.doLast(new AndroidResourceCopyAction())
-            })
+                { t ->
+                    t.description = "gathers all *.jar and AndroidManifest.xml files into the Plugins/Android directory of the unity project"
+                    t.dependsOn(androidResources)
+                    t.resources androidResources
+                    t.doLast(new AndroidResourceCopyAction())
+                })
 
         def webglResourceCopy = project.tasks.register("assembleWebGLResources", DefaultResourceCopyTask,
-            { t ->
-                t.description = "gathers all webgl related files into the Plugins/webGL directory of the unity project"
-                t.dependsOn(webglResources)
-                t.resources webglResources
-                t.doLast(new WebGLResourceCopyAction())
-            })
+                { t ->
+                    t.description = "gathers all webgl related files into the Plugins/webGL directory of the unity project"
+                    t.dependsOn(webglResources)
+                    t.resources webglResources
+                    t.doLast(new WebGLResourceCopyAction())
+                })
 
         def assembleTask = project.tasks[ASSEMBLE_RESOURCES_TASK_NAME]
         assembleTask.dependsOn iOSResourceCopy, androidResourceCopy, webglResourceCopy
@@ -382,14 +382,12 @@ class WdkUnityPlugin implements Plugin<Project> {
             defaultTask.publishIvy = false
         })
 
-        // Configure the publishing task dependencies
-        def artifactoryPublishTask = project.tasks.getByName("artifactoryPublish")
-        def publishTask = project.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
-        publishTask.dependsOn(artifactoryPublishTask)
-
-        if (project.rootProject != project) {
-            def rootPublishTask = project.rootProject.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
-            rootPublishTask.dependsOn(publishTask)
+        project.afterEvaluate {
+            def publishTask = project.tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+            if(upmPack.get().onlyIf.isSatisfiedBy(upmPack.get())) {
+                def artifactoryPublishTask = project.tasks.named("artifactoryPublish")
+                publishTask.dependsOn(artifactoryPublishTask)
+            }
         }
     }
 
@@ -402,7 +400,7 @@ class WdkUnityPlugin implements Plugin<Project> {
                 // Search for a directory that contains a package.json file
                 def tree = woogaDir.asFileTree
                 def manifestFiles = tree.filter({ File file -> file.name == "package.json" })
-                switch (manifestFiles.size()){
+                switch (manifestFiles.size()) {
                     case 1:
                         def manifest = manifestFiles.first()
                         result = woogaDir.dir(manifest.parentFile.path)
@@ -419,6 +417,6 @@ class WdkUnityPlugin implements Plugin<Project> {
                 logger.warn("Could not deduce the package directory for this wdk")
             }
             result
-        })
+        }.memoize())
     }
 }


### PR DESCRIPTION
## Description

The last release added a small issue with the way the publish setup. The configuration for the upmPack and creation depends on the `packageDir` being set. The problem is that a publications should not be conditional. Either they work or not. In our case here the publish needs to be conditional. So I made the decision to only add the dependency to the main `publish` task if all the configuration settings are available. The general `artifactoryPublish` would still fail.

## Changes

* ![FIX] publish with non set upm package directory


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
