### PR TITLE
Adds task to resolve packages when setup is called by itself

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/AssembleResourcesIntegrationSpec.groovy
@@ -23,7 +23,7 @@ import spock.lang.Unroll
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-class AssembleResourcesIntegrationSpec extends IntegrationSpec {
+class AssembleResourcesIntegrationSpec extends UnityIntegrationSpec {
 
     File iOSResourcebase
     File androidResourcebase

--- a/src/integrationTest/groovy/wooga/gradle/wdk/unity/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/wdk/unity/IntegrationSpec.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.wdk.unity
 
-class IntegrationSpec extends nebula.test.IntegrationSpec {
+class IntegrationSpec extends com.wooga.gradle.test.IntegrationSpec  {
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")


### PR DESCRIPTION
## Description

Adds a task, `resolvePackages`, which has been added onto the pseudo `setup` lifecycle task this plugin adds. It will be called whenever `setup` is invoked by itself, with no other Unity tasks.

## Changes
* ![ADD] `resolvePackages` task, `setup` task dependency

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
