### PR TITLE
Add support for AtlasBuildTools integration when added via UPM

### DIFF
--- a/src/test/groovy/wooga/gradle/wdk/unity/WdkTestBuildSpec.groovy
+++ b/src/test/groovy/wooga/gradle/wdk/unity/WdkTestBuildSpec.groovy
@@ -31,6 +31,67 @@ class WdkTestBuildSpec extends ProjectSpec {
     }
 
     @Unroll
+    def "generates task :#taskName when upm package 'com.wooga.atlas-build-tools' is available"() {
+        given: "project manifest file with dependency to atlas-build-tools"
+        File manifestFile = new File(projectDir,"Packages/manifest.json")
+        manifestFile.parentFile.mkdirs()
+        manifestFile << """
+        {
+            "dependencies": {
+                "com.wooga.atlas-build-tools": "1.17.2",
+            }
+        }
+        """.stripIndent()
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def task = project.tasks.findByName(taskName)
+        taskType.isInstance(task)
+
+        where:
+        taskName                                                | taskType
+        WdkUnityPlugin.MOVE_EDITOR_DEPENDENCIES                 | DefaultTask
+        WdkUnityPlugin.UN_MOVE_EDITOR_DEPENDENCIES              | DefaultTask
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME             | DefaultTask
+        WdkUnityPlugin.CLEAN_TEST_BUILD_TASK_NAME               | Unity
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "IOS"     | Unity
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "Android" | Unity
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "WebGL"   | Unity
+    }
+
+    @Unroll
+    def "skips generation of task :#taskName when upm package 'com.wooga.atlas-build-tools' is not available"() {
+        given: "project manifest file with dependency to atlas-build-tools"
+        File manifestFile = new File(projectDir,"Packages/manifest.json")
+        manifestFile.parentFile.mkdirs()
+        manifestFile << """
+        {
+            "dependencies": {
+                "com.wooga.some-dependency": "1.17.2",
+            }
+        }
+        """.stripIndent()
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        !project.tasks.findByName(taskName)
+
+        where:
+        taskName                                                | _
+        WdkUnityPlugin.MOVE_EDITOR_DEPENDENCIES                 | _
+        WdkUnityPlugin.UN_MOVE_EDITOR_DEPENDENCIES              | _
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME             | _
+        WdkUnityPlugin.CLEAN_TEST_BUILD_TASK_NAME               | _
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "IOS"     | _
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "Android" | _
+        WdkUnityPlugin.PERFORM_TEST_BUILD_TASK_NAME + "WebGL"   | _
+    }
+
+    @Unroll
     def "generates task :#taskName when 'AtlasBuildTools' is available"() {
         given: "paket.unity.references file with AtlasBuildTools"
         File reference = new File(projectDir, "paket.unity3d.references")


### PR DESCRIPTION
## Description

This patch adds support to add the test build setup when the package `AtlasBuildTools` is added via upm as package `com.wooga.atlas-build-tools`.

There is a slight issue with this implementation as it evaluates the `projectManifestFile` property from the unity extension. The whole generation should be lazy here but that would make the setup more complicated and the test setup would need to be completely rewritten.

I opted for this solution since the plugin is opinionated anyways, and we usually can't override the location for the manifest file anyways.

## Changes

* ![ADD] support for AtlasBuildTools integraton when added via UPM




[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
