### PR TITLE
makes cleanupDanglingUnityFiles run before every unity task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,25 @@
-FROM openjdk:8-jdk
+ARG RUST_VERSION=1.50.0
 
+FROM rust:$RUST_VERSION
+ARG UVM_VERSION=2.2.0
 
-RUN mkdir -p /home/ci
-
-# Create an app user so our program doesn't run as root.
-RUN groupadd -r ci &&\
-    useradd -r -g ci -d /home/ci -s /sbin/nologin -c "Docker image user" ci
-
-# Set the home directory to our app user's home.
-ENV HOME=/home/ci
 ENV RUST_BACKTRACE=1
 ENV RUST_LOG="warning, uvm_core=trace, uvm_jni=trace"
 ENV IN_DOCKER="1"
 
-RUN apt-get update
-RUN apt-get install -y  build-essential libssl-dev pkg-config openssl p7zip-full cpio -y
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl -Lo "unity-version-manager-$UVM_VERSION.tar.gz" "https://github.com/Larusso/unity-version-manager/archive/v$UVM_VERSION.tar.gz"
+RUN tar -xzf "unity-version-manager-$UVM_VERSION.tar.gz" && rm "unity-version-manager-$UVM_VERSION.tar.gz"
 
-ENV PATH="${HOME}/.cargo/bin:${PATH}"
+RUN cd "unity-version-manager-$UVM_VERSION" && PATH="${HOME}/.cargo/bin:$PATH" make install
 
-WORKDIR /home/ci/
+FROM openjdk:11-jdk-buster
+ARG USER_ID=1001
+ARG GROUP_ID=100
 
-RUN curl -Lo unity-version-manager-2.2.0.tar.gz https://github.com/Larusso/unity-version-manager/archive/v2.2.0.tar.gz && \
-    tar -xzf unity-version-manager-2.2.0.tar.gz && \
-    cd unity-version-manager-2.2.0 && make install && \
-    uvm install 2019.1.0a7 /home/ci/.local/share/Unity-2019.1.0a7
+RUN useradd -u ${USER_ID} -g ${GROUP_ID} --create-home jenkins_agent
 
-# Chown all the files to the app user.
-RUN chown -R ci:ci $HOME
-RUN chmod -R 777 $HOME
+USER jenkins_agent
+COPY --from=0 /usr/local/bin/uvm* ./usr/local/bin/
+
+RUN uvm install 2019.1.0a7 /home/jenkins_agent/.local/share/Unity-2019.1.0a7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,7 @@ withCredentials([
                     string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
                     string(credentialsId: 'snyk-wooga-frontend-integration-token', variable: 'SNYK_TOKEN')
                  ]) {
-    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], sonarToken: sonar_token
+    buildGradlePlugin platforms: ['macos', 'windows', 'linux'],
+                        sonarToken: sonar_token,
+                        dockerArgs: [ dockerArgs: ['-v', '/home/jenkins_agent/.gradle:/home/jenkins_agent/.gradle'] ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '5.0.0-rc.2'
+    id 'net.wooga.plugins' version '5.0.0'
     id 'net.wooga.snyk' version '0.12.0'
     id 'net.wooga.snyk-gradle-plugin' version '0.6.0'
     id "net.wooga.cve-dependency-resolution" version "0.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ plugins {
 group 'net.wooga.gradle'
 description = 'Plugin for wooga unity package development.'
 
+java.sourceCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_11
+
 pluginBundle {
     website = 'https://wooga.github.io/atlas-wdk-unity/'
     vcsUrl = 'https://github.com/wooga/atlas-wdk-unity'
@@ -53,7 +56,7 @@ cveHandler {
 dependencies {
     implementation 'org.apache.maven:maven-artifact:3.8.5'
     implementation "net.wooga.gradle:dotnet-sonarqube:[1,2["
-    implementation "net.wooga.gradle:unity:[4,5["
+    implementation "net.wooga.gradle:unity:[5,6["
     implementation "commons-io:commons-io:2.11.0"
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
 

--- a/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/wdk/unity/WdkUnityPlugin.groovy
@@ -228,6 +228,11 @@ class WdkUnityPlugin implements Plugin<Project> {
             }
         }
 
+        def cleanupUnityFiles = project.tasks.named(UnityPlugin.Tasks.cleanupDanglingUnityFiles.toString())
+        project.tasks.withType(UnityTask).configureEach {
+            it.dependsOn(cleanupUnityFiles)
+        }
+
         // Make every other Unity task depend on the setup task defined by this plugin
         project.tasks.withType(UnityTask).configureEach { task ->
             if (task.name != RESOLVE_PACKAGES_TASK_NAME && task.name && !(task.name == UnityPlugin.Tasks.ensureProjectManifest.name())

--- a/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/wdk/unity/WdkUnityPluginSpec.groovy
@@ -19,12 +19,14 @@ package wooga.gradle.wdk.unity
 
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import spock.lang.Unroll
 import wooga.gradle.dotnetsonar.DotNetSonarqubePlugin
 import wooga.gradle.dotnetsonar.SonarScannerExtension
 import wooga.gradle.dotnetsonar.tasks.BuildSolution
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.UnityTask
 import wooga.gradle.wdk.unity.tasks.ResourceCopyTask
 
 class WdkUnityPluginSpec extends ProjectSpec {
@@ -66,6 +68,23 @@ class WdkUnityPluginSpec extends ProjectSpec {
         WdkUnityPlugin.SETUP_TASK_NAME                      | DefaultTask
         WdkUnityPlugin.SONARQUBE_BUILD_TASK_NAME            | BuildSolution
         WdkUnityPlugin.SONARQUBE_TASK_NAME                  | DefaultTask
+    }
+
+    def 'any UnityTask depends on #dependencies' () {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+        and:
+        def anyUnityTask = project.tasks.register("anyUnityTask", UnityTask).get()
+
+        then:
+        anyUnityTask.getTaskDependencies().getDependencies(anyUnityTask).any { t ->
+            dependencies.contains(t.name.replaceFirst(":",""))
+        }
+        where:
+        dependencies = [UnityPlugin.Tasks.cleanupDanglingUnityFiles.toString()]
     }
 
     @Unroll


### PR DESCRIPTION
## Description
Sets `cleanupDanglingUnityFiles` as a dependency of all `UnityTask`s. This is to assure that there aren't any leftover lockfiles and temp files from previous crashed unity instances. 

As we need to update `net.wooga.unity` to 6.x, this plugin is not compatible with java < 11 anymore.


## Changes
* ![ADD] `cleanupDanglingUnityFiles` as a dependency of all `UnityTask`s
* ![UPDATE] `net.wooga.unity` to 6.x
* ![CHANGE] this plugin is now only compatible with java 11 and ownwards




[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
